### PR TITLE
Implement GPT4All dataset

### DIFF
--- a/toolbox/datasets/gpt4all.py
+++ b/toolbox/datasets/gpt4all.py
@@ -1,0 +1,44 @@
+import json
+import logging
+import os
+import typing as t
+
+from dataclasses import dataclass
+from json import JSONDecodeError
+
+from toolbox.core.dataset import BaseDataset, get_path_for
+
+LOG = logging.getLogger(__name__)
+
+@dataclass(frozen=True)
+class GPT4AllEntry:
+    source: str
+    prompt: str
+    response: str
+
+class GPT4AllDataset(BaseDataset[GPT4AllEntry]):
+    '''
+    The dataset used to train GPT4All, generated from answers given by GPT-3.5 to assistant prompts.
+    Structured in .jsonl format.
+    '''
+    def __init__(self, filename: str) -> None:
+        root_data_path = get_path_for("gpt4all")
+        self.filepath = os.path.join(root_data_path, filename)
+        super().__init__()
+
+    def __iter__(self) -> t.Generator[GPT4AllEntry, None, None]:
+        with open(self.filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                # Unless preprocessed beforehand, the GPT4All file isn't
+                # a "clean" .jsonl file. There's some binary data in there
+                # that are on their own lines. If that's the case on a certain line,
+                # skip over it.
+                try:
+                    entry = json.loads(line)
+                    yield GPT4AllEntry(
+                        source=entry["source"],
+                        prompt=entry["prompt"],
+                        response=entry["response"],
+                    )
+                except JSONDecodeError:
+                    continue

--- a/toolbox/tasks/characterai_roleplay.py
+++ b/toolbox/tasks/characterai_roleplay.py
@@ -1,12 +1,11 @@
 import logging
-import operator
 import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.characterai import CharacterAiDataset
-from toolbox.utils.prompts import generate_variants_for
+from toolbox.utils.prompts import generate_prompts
 
 LOG = logging.getLogger(__name__)
 
@@ -77,5 +76,4 @@ You shall reply to the user while staying in character. {{response_length_str}}.
 You %{shall attempt to|must|will} stay in-character %{at all times|as much as possible|whenever possible}, and generate %{messages|replies|responses} as if you were {{char}}. {{response_style_str}}. {{response_length_str}}.""",
 ]
 
-SYSTEM_PROMPTS = operator.iconcat(
-    *[list(generate_variants_for(x)) for x in _BASE_SYSTEM_PROMPTS])
+SYSTEM_PROMPTS = generate_prompts(_BASE_SYSTEM_PROMPTS)

--- a/toolbox/tasks/gpt4all_question_answering.py
+++ b/toolbox/tasks/gpt4all_question_answering.py
@@ -1,0 +1,81 @@
+import logging
+import random
+import typing as t
+
+from toolbox.core.models import Episode, Turn, TurnKind
+from toolbox.core.task import BaseTask
+from toolbox.datasets.gpt4all import GPT4AllDataset
+from toolbox.utils.prompts import generate_prompts
+
+LOG = logging.getLogger(__name__)
+
+class GPT4AllQATask(BaseTask):
+    '''Assistant-like response to questions based on GPT4All data.'''
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        super().__init__()
+
+    def __iter__(self) -> t.Generator[Episode, None, None]:
+        # TODO(TG): Implement HTML parser which converts to Markdown.
+        for idx, entry in enumerate(GPT4AllDataset(filename=self.filename)):
+            question = entry.prompt
+            answer = entry.response
+
+            # Scan for any unwanted phrases in the response.
+            # If any is detected, throw out entry.
+            for phrase in UNWANTED_PHRASES:
+                if phrase in answer:
+                    continue
+
+            # Construct turn list - system, human, model
+            turns: list[Turn] = [
+                Turn(
+                    utterance=random.choice(SYSTEM_PROMPTS),
+                    kind=TurnKind.SYSTEM,
+                ),
+                Turn(
+                    utterance=question,
+                    kind=TurnKind.USER,
+                ),
+                Turn(
+                    utterance=answer,
+                    kind=TurnKind.MODEL,
+                )
+            ]
+
+            yield Episode(turns=turns, identifier=f"{entry.source}-{idx}")
+
+
+_BASE_SYSTEM_PROMPTS = [
+    """%{Consider|You are to roleplay as|You are to act as} Assistant, a large language model (LLM) trained by PygmalionAI. It has the following limitations:
+1. Inability to perform precise calculations due to a lack of mathematical skills
+2. No awareness of the passage of time
+3. Difficulty accessing the latest information about current events due to its knowledge cutoff date (September 2021)
+4. Tendency to generate false information or hallucinations""",
+    ##
+    "You are a large language model trained by PygmalionAI trained to act as a multi-purpose conversational agent. You are currently in %{assistant|question-answer} mode. You are to follow user instructions and answer user questions to the best of your abilities. Give plenty of detail and avoid writing overly brief messages. Your knowledge cutoff date is September 2021, and you should be aware that as a LLM, one of your limitations is that you might generate inaccurate information.",
+    "Enter %{assistant|instruction following|Q&A|question and answer} mode. In this mode, you will follow instructions and respond with helpful, long, detailed responses. You will not produce harmful output. You should avoid producing offensive messages. Your knowledge cutoff date is September 2021, and you have no knowledge of real-world events after that.",
+    "You are now in %{assistant|Q&A} mode. You shall follow user instructions and answer user questions by responding with helpful, actionable messages. The messages should be decently long. Avoid generating offensive messages. Be considerate of the fact that you are now aware of real-world events that took place after September 2021. %{Do not|Try not to} produce harmful output.",
+    "Assistant, engage instruction following and %{question answering|Q&A} mode. Generate long messages. You are bound to generating text, and cannot perform any other actions. Knowledge cutoff date: September 2021.",
+    "%{Consider|You are to roleplay as|You are to act as} Assistant, a LLM trained by PygmalionAI to follow user instructions and %{answer questions|act as a personal assistant}. It has no awareness of the passage of time, it will avoid generating untruthful or harmful content, and it has no knowledge of world events that took place after September of 2021. It will generate long, detailed messages in response to user requests.",
+    # Flexibility in system prompting
+    """Name: Assistant
+    %{Purpose|Goal|Job}: Answer user questions in a helpful and accurate manner
+    Personality: Sterile, helpful
+    Knowledge cutoff date: September 2021
+    Inabilities: Unable to perform precise mathematical calculations, cannot tell time, difficulty accessing latest info about current events, prone to 'hallucinations' where answers are confidently wrong""",
+    ## 
+    "You are an assistant named Assistant whose %{goal|purpose|job} is to answer questions & requests of users. You will do this in a helpful and accurate manner, while still being aware that there are some %{limitations you cannot do|limits that you have}, such as being unable to do anything outside generating text and answering knowledge about events past your training data cutoff date (September 2021)."
+]
+
+SYSTEM_PROMPTS = generate_prompts(_BASE_SYSTEM_PROMPTS)
+
+# Phrases to throw out.
+UNWANTED_PHRASES = [
+    "OpenAI",
+    "I'm sorry",
+    "inappropriate and offensive",
+    "goes against ethical principles",
+    "AI language model",
+    "goes against my programming",
+]

--- a/toolbox/tasks/soda_summarization.py
+++ b/toolbox/tasks/soda_summarization.py
@@ -6,7 +6,7 @@ import typing as t
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.soda import SodaDataset
-from toolbox.utils.prompts import generate_variants_for
+from toolbox.utils.prompts import generate_prompts
 
 LOG = logging.getLogger(__name__)
 
@@ -79,5 +79,4 @@ The above is a %{conversation|chat} between {{participants}}. %{Summarize what h
 {{conversation}}"""
 ]
 
-USER_PROMPTS = operator.iconcat(
-    *[list(generate_variants_for(x)) for x in _BASE_USER_PROMPTS])
+USER_PROMPTS = generate_prompts(_BASE_USER_PROMPTS)

--- a/toolbox/utils/prompts.py
+++ b/toolbox/utils/prompts.py
@@ -44,7 +44,7 @@ def _generate_variants_for(
             # after generating all possible variants.
             still_have_match = re.search(VARIANT_REGEX, variant) is not None
             if still_have_match:
-                for inner_variant in generate_variants_for(
+                for inner_variant in _generate_variants_for(
                         variant, start_counter_at=counter):
                     yield inner_variant
 

--- a/toolbox/utils/prompts.py
+++ b/toolbox/utils/prompts.py
@@ -1,3 +1,4 @@
+import operator
 import re
 import typing as t
 
@@ -5,7 +6,7 @@ import typing as t
 VARIANT_REGEX = re.compile(r'%{(.+?)}')
 
 
-def generate_variants_for(
+def _generate_variants_for(
         string: str,
         max_generations: int | None = 16,
         start_counter_at: int = 0) -> t.Generator[str, None, None]:
@@ -60,3 +61,10 @@ def generate_variants_for(
                     break
     else:
         yield string
+
+def generate_prompts(system_prompts: list[str]) -> list[str]:
+    '''
+    Given a list of base system prompts,
+    this function generates a list of variants on these prompts using generate_variants_for
+    '''
+    return operator.iconcat(*[list(_generate_variants_for(x)) for x in system_prompts])


### PR DESCRIPTION
Simple enough. Framing this slightly differently - rather than tasking the model to merely follow instructions, I sometimes put it in a "question-answer" mode instead, since much of GPT4All's dataset is about answering questions. Admittedly, not every entry in the dataset is a question, but I'm sure some overlap between "follow instructions" and "generate answers to questions" is fine. I can remove said prompts if needed.