### PR TITLE
Refactor training example formats and add Alpaca format

### DIFF
--- a/build_data.py
+++ b/build_data.py
@@ -52,7 +52,7 @@ def main() -> None:
                 print_new_episode_header = False
             
             try:
-                for example in TrainingExampleGenerator(episode):
+                for example in TrainingExampleGenerator(episode, target_token_count=args.max_length, format=args.format):
                     # Right off the bat, if this training example gets caught by one
                     # of the filters, skip over and don't even count it.
                     should_keep = True
@@ -120,17 +120,34 @@ def _parse_args_from_argv() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "-p",
-        "--print",
-        action="store_true",
-        help="Print training examples instead of writing to STDOUT."
-    )
-
-    parser.add_argument(
         "-f",
         "--filters",
         type=str,
         help="List of comma-separated filters to apply to training examples."
+    )
+
+    parser.add_argument(
+        "-l",
+        "--max-length",
+        type=int,
+        default=2048,
+        # TODO(TG): Explain this more clearly
+        help="The (approximate) amount of tokens to limit episodes to."
+    )
+
+    parser.add_argument(
+        "-m",
+        "--format",
+        type=str,
+        default="metharme",
+        help="The format for the training data to use (accepted inputs: 'pygmalion', 'metharme'). Defaults  'metharme'"
+    )
+
+    parser.add_argument(
+        "-p",
+        "--print",
+        action="store_true",
+        help="Print training examples instead of writing to STDOUT."
     )
 
     parser.add_argument(

--- a/toolbox/core/models.py
+++ b/toolbox/core/models.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
 
-
 class TurnKind(Enum):
     '''Identifies who a turn "belongs" to.'''
     SYSTEM = "<|system|>"
@@ -15,23 +14,12 @@ class Turn:
     kind: TurnKind
     # Used only for Pygmalion format
     name: str = "<BOT>"
-
-    def as_meth_str(self) -> str:
-        return f"{self.kind.value}{self.utterance}"
-
-    def as_pyg_str(self) -> str:
-        # Handle system prompt separately
-        if self.kind == TurnKind.SYSTEM:
-            return f"{self.name}'s Persona: {self.utterance}\n<START>"
-        else:
-            return f"{self.name}: {self.utterance}"
-
+        
 @dataclass(frozen=True)
 class Episode:
     '''A collection of turns.'''
     turns: list[Turn]
     identifier: str
-
 
 @dataclass(frozen=True)
 class TrainingExample:

--- a/toolbox/core/wrapper.py
+++ b/toolbox/core/wrapper.py
@@ -1,0 +1,99 @@
+"""
+NOTE(TG): I still think there's a better way to handle multiple formats than this.
+It's just a gut feeling.
+"""
+
+from abc import ABC, abstractmethod
+from toolbox.core.models import Turn, TurnKind
+
+class TurnWrapper(ABC):
+    def __init__(self, turn: Turn) -> None:
+        '''Abstract wrapper for the purpose of easily constructing examples.'''
+        self.turn = turn
+        # Make accessing the values of Turn easier
+        self.utterance = turn.utterance
+        self.kind = turn.kind
+        self.name = turn.name
+
+    @abstractmethod
+    def as_str(self) -> str:
+        '''Convert a turn into a training example'''
+        raise NotImplementedError
+    
+    @abstractmethod
+    def get_model_turn(self) -> str:
+        '''Get the model turn portion of the turn'''
+        raise NotImplementedError
+    
+class MetharmeWrapper(TurnWrapper):
+    def __init__(self, turn: Turn) -> None:
+        super().__init__(turn)
+
+    def as_str(self) -> str:
+        return f"{self.kind.value}{self.utterance}"
+    
+    def get_model_turn(self) -> str:
+        return TurnKind.MODEL.value
+    
+class PygmalionWrapper(TurnWrapper):
+    def __init__(self, turn: Turn) -> None:
+        super().__init__(turn)
+
+    def as_str(self) -> str:
+        if self.kind == TurnKind.SYSTEM:
+            return f"{self.name}'s Persona: {self.utterance}\n<START>"
+        else:
+            return f"{self.name}: {self.utterance}"
+    
+    def get_model_turn(self) -> str:
+        return f"\n{self.name}: "
+    
+class AlpacaWrapper(TurnWrapper):
+    def __init__(self, turn: Turn) -> None:
+        super().__init__(turn)
+        self.kind_map: [TurnKind, str] = {
+            TurnKind.SYSTEM: "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:",
+            TurnKind.USER: "### Input:",
+            TurnKind.MODEL: "### Response:"
+        }
+
+    def as_str(self) -> str:
+        return f"{self.kind_map[self.kind]}\n{self.utterance}\n\n"
+    
+    def get_model_turn(self) -> str:
+        return f"{self.kind_map[TurnKind.MODEL]}\n"
+    
+class MinimalAlpacaWrapper(TurnWrapper):
+    def __init__(self, turn: Turn) -> None:
+        super().__init__(turn)
+    
+    def as_str(self) -> str:
+        # System prompt and user are under the same block
+        if self.kind != TurnKind.MODEL:
+            return f"### Instruction:\n{self.utterance}\n"
+        else:
+            return f"### Response:\n{self.utterance}\n"
+        
+    def get_model_turn(self) -> str:
+        return f"### Response:\n"
+    
+class HenkpacaWrapper(TurnWrapper):
+    def __init__(self, turn: Turn) -> None:
+        super().__init__(turn)
+
+    def as_str(self) -> str:
+        if self.kind == TurnKind.SYSTEM:
+            return f"### Instruction:\n{self.utterance}\n### Response:\n"
+        else:
+            return f"{self.name}: {self.utterance}\n"
+        
+    def get_model_turn(self) -> str:
+        return f"{self.name}: "
+
+WRAPPER_MAP: dict[str, TurnWrapper] = {
+    "metharme": MetharmeWrapper,
+    "pygmalion": PygmalionWrapper,
+    "alpaca": AlpacaWrapper,
+    "minimal_alpaca": MinimalAlpacaWrapper,
+    "henkpaca": HenkpacaWrapper,
+}

--- a/toolbox/core/wrapper.py
+++ b/toolbox/core/wrapper.py
@@ -1,8 +1,3 @@
-"""
-NOTE(TG): I still think there's a better way to handle multiple formats than this.
-It's just a gut feeling.
-"""
-
 from abc import ABC, abstractmethod
 from toolbox.core.models import Turn, TurnKind
 


### PR DESCRIPTION
*Long blogpost inbound.*

**TL;DR**: New Alpaca formats. Refactored code to support more than two formats.

Many users of the Pyg models have found that our Metharme format, while a bit better than the old Pygmalion format, to be somewhat confusing and obtuse. In addition, front-end developers for UIs handling LLMs have noted that this unique format can put a strain on their development efforts as they must keep up with another format to handle. With these factors in mind, it's rather likely that our next Pygmalion models will be trained with the Alpaca format. And so I set out to add the Alpaca format. Except... there's a problem. As it turns out, there's about [nine million](https://www.youtube.com/watch?v=5Cv5whdF4FI) different variations on the Alpaca format (and instruct formats in general). For now, I've decided to add three: the standard Alpaca format, a "minimal Alpaca" made by Henk from [KoboldAI](https://github.com/henk717/KoboldAI) as well as "Henkpaca", another format he made which (in my own words) acts as a kind of hybrid between instruct and chat formats. It might genuinely be worth it to try this out.

In the beginning, this repo only needed to support one format: Metharme's. Then, way later on, I decided to add the old Pygmalion format. While it was quite different from the Metharme format, it was nevertheless rather simple to implement. And since there were only two formats, I only needed to write a few if-else statements, and that was that. Adding three more formats., however, means that that is no longer an option without having to write a bunch of `elif`s. A different approach was needed.

This approach comes in the idea of the `TurnWrapper`. Instead of having a bunch of different methods in the `Turn` class to try and handle all the different formats, we instead have an abstract `TurnWrapper` class which takes in a `Turn` as a parameter and has methods for both representing the turn as a string and just grabbing the "model marker" (if that makes any sense) segment of the format. Different formats can then inherit from this base class. The attributes of the `Turn` which is fed into it are linked in `TurnWrapper` - this means that no changes to the turn-processing code beyond simply wrapping it in a subclass of `TurnWrapper` are needed. A `WRAPPER_MAP` mapping is provided so that no if-else statements are needed in terms of selecting which format belongs to which wrapper. All of this also means that it is pretty damn easy to add a new format: just make a subclass of `TurnWrapper`, add it to `WRAPPER_MAP`, specify it as a valid format in the new `VALID_FORMATS` constant in `toolbox/core/training_example.py`, and you're good to go.

Honestly, I really have no idea why I wrote so much. It's like 12 AM lol, I'm just gonna merge this and go to bed