### PR TITLE
Add ChatML format

### DIFF
--- a/toolbox/core/training_example.py
+++ b/toolbox/core/training_example.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 # at training time.
 AVG_WORD_TO_TOKEN_RATIO = 1.7
 
-VALID_FORMATS = ["metharme", "pygmalion", "alpaca", "minimal_alpaca", "henkpaca"]
+VALID_FORMATS = ["metharme", "pygmalion", "alpaca", "minimal_alpaca", "henkpaca", "chatml"]
 
 class TurnTooLargeError(RuntimeError):
     pass
@@ -95,6 +95,9 @@ class TrainingExampleGenerator:
             prompt += turn.get_model_turn()
             
             generation = turn.utterance.strip()
+            # ChatML format prefers to end with its own end token rather than the model's.
+            if self.format == "chatml":
+                generation += "<|im_end|>"
 
             # Sanity checks. Asserts that there's only a single system prompt
             # and it's at the very beginning of the prompt string.

--- a/toolbox/core/training_example.py
+++ b/toolbox/core/training_example.py
@@ -9,7 +9,7 @@ from toolbox.core.models import (
     TrainingExample,
     TurnKind
 )
-from toolbox.core.wrapper import WRAPPER_MAP
+from toolbox.core.wrapper import VALID_FORMATS, WRAPPER_MAP
 
 LOG = logging.getLogger(__name__)
 
@@ -18,8 +18,6 @@ LOG = logging.getLogger(__name__)
 # can instead use an estimation instead if we're OK with dropping some examples
 # at training time.
 AVG_WORD_TO_TOKEN_RATIO = 1.7
-
-VALID_FORMATS = ["metharme", "pygmalion", "alpaca", "minimal_alpaca", "henkpaca", "chatml"]
 
 class TurnTooLargeError(RuntimeError):
     pass

--- a/toolbox/core/wrapper.py
+++ b/toolbox/core/wrapper.py
@@ -46,7 +46,7 @@ class PygmalionWrapper(TurnWrapper):
 class AlpacaWrapper(TurnWrapper):
     def __init__(self, turn: Turn) -> None:
         super().__init__(turn)
-        self.kind_map: [TurnKind, str] = {
+        self.kind_map: dict[TurnKind, str] = {
             TurnKind.SYSTEM: "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:",
             TurnKind.USER: "### Input:",
             TurnKind.MODEL: "### Response:"
@@ -84,6 +84,24 @@ class HenkpacaWrapper(TurnWrapper):
         
     def get_model_turn(self) -> str:
         return f"{self.name}: "
+    
+class ChatMlWrapper(TurnWrapper):
+    def __init__(self, turn: Turn) -> None:
+        '''
+        Plain-text version of ChatML as described here: https://github.com/openai/openai-python/blob/main/chatml.md
+        '''
+        super().__init__(turn)
+        self.kind_map: dict[TurnKind, str] = {
+            TurnKind.SYSTEM: "system",
+            TurnKind.USER: "user",
+            TurnKind.MODEL: "assistant",
+        }
+
+    def as_str(self) -> str:
+        return f"<|im_start|>{self.kind_map[self.kind]}\n{self.utterance}<|im_end|>\n"
+    
+    def get_model_turn(self) -> str:
+        return f"<|im_start|>{self.kind_map[TurnKind.MODEL]}\n"
 
 WRAPPER_MAP: dict[str, TurnWrapper] = {
     "metharme": MetharmeWrapper,
@@ -91,4 +109,5 @@ WRAPPER_MAP: dict[str, TurnWrapper] = {
     "alpaca": AlpacaWrapper,
     "minimal_alpaca": MinimalAlpacaWrapper,
     "henkpaca": HenkpacaWrapper,
+    "chatml": ChatMlWrapper,
 }

--- a/toolbox/core/wrapper.py
+++ b/toolbox/core/wrapper.py
@@ -111,3 +111,5 @@ WRAPPER_MAP: dict[str, TurnWrapper] = {
     "henkpaca": HenkpacaWrapper,
     "chatml": ChatMlWrapper,
 }
+
+VALID_FORMATS = ["metharme", "pygmalion", "alpaca", "minimal_alpaca", "henkpaca", "chatml"]

--- a/toolbox/core/wrapper.py
+++ b/toolbox/core/wrapper.py
@@ -102,6 +102,20 @@ class ChatMlWrapper(TurnWrapper):
     
     def get_model_turn(self) -> str:
         return f"<|im_start|>{self.kind_map[TurnKind.MODEL]}\n"
+    
+class ChatMlWithNameWrapper(ChatMlWrapper):
+    def __init__(self, turn: Turn) -> None:
+        '''
+        Plain-text version of ChatML as described here: https://github.com/openai/openai-python/blob/main/chatml.md
+        This version with a name.
+        '''
+        super().__init__(turn)
+
+    def as_str(self) -> str:
+        return f"<|im_start|>{self.kind_map[self.kind]} name={self.name}\n{self.utterance}<|im_end|>\n"
+    
+    def get_model_turn(self) -> str:
+        return f"<|im_start|>{self.kind_map[TurnKind.MODEL]} name={self.name}\n"
 
 WRAPPER_MAP: dict[str, TurnWrapper] = {
     "metharme": MetharmeWrapper,
@@ -110,6 +124,7 @@ WRAPPER_MAP: dict[str, TurnWrapper] = {
     "minimal_alpaca": MinimalAlpacaWrapper,
     "henkpaca": HenkpacaWrapper,
     "chatml": ChatMlWrapper,
+    "chatml_named": ChatMlWithNameWrapper
 }
 
-VALID_FORMATS = ["metharme", "pygmalion", "alpaca", "minimal_alpaca", "henkpaca", "chatml"]
+VALID_FORMATS = ["metharme", "pygmalion", "alpaca", "minimal_alpaca", "henkpaca", "chatml", "chatml_named"]


### PR DESCRIPTION
Quick job I did to add OpenAI's [ChatML](https://github.com/openai/openai-python/blob/main/chatml.md) format. This is the basic plaintext version - no fancy JSON objects with this one. One variant is the regular ChatML format, and the other is a modified variant of their last example in that document that includes names (and thus the `Turn` object's `name` attribute.) The original purpose was just for designating few-shot prompting, but a named variant can come in handy here.

Merging quickly since it's tested and working.