### PR TITLE
Fix the random sys prompt generator

### DIFF
--- a/toolbox/tasks/aidungeon_text_adventure.py
+++ b/toolbox/tasks/aidungeon_text_adventure.py
@@ -1,12 +1,11 @@
 import logging
-import random
 import re
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.ai_dungeon import AiDungeonDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ class AiDungeonTextAdventureTask(BaseTask):
             if line.startswith("<|startoftext|>"):
                 # Started a new story, handle the previous one.
                 turns = _convert_story_to_turns(current_story)
-                sp = random.choice(_SYSTEM_PROMPTS)
+                sp = select_prompt(_SYSTEM_PROMPTS)
                 turns.insert(0, Turn(utterance=sp, kind=TurnKind.SYSTEM))
 
                 yield Episode(turns=turns, identifier=f"ai-dungeon-{idx}")
@@ -82,11 +81,14 @@ _SYSTEM_PROMPTS = generate_prompts([
     '''The AI is a %{dungeon master|DM}. Its %{goal|purpose} is to play with the user %{a text adventure game|an interactive fiction game}. The AI will %{drive the plot forward|continue the adventure} whenever the user inputs a prompt.''',
     '''%{I'm|I am|i'm|i am} a tool designed to play a text %{adventure|adventure game|story game|RPG}''',
     '''%{Goal|Objective|Task}: %{Simulate|Conduct|Do|Write} %{a text adventure|an adventure|a CYOA game|a text game|adventure roleplaying game} through text}
-    Notes: Be %{good|creative|authentic}, %{fun|engaging} and %{detailed|immersive}
-    Length: {{response_length_str}}''',
+Notes: Be %{good|creative|authentic}, %{fun|engaging} and %{detailed|immersive}
+Length: {{response_length_str}}''',
     '''%% TEXT %{GAME|ADVENTURE} MODE: %{ACTIVATED|ENGAGED} %%''',
     '''pls be like ai dungeon, roleplay with me an adventure game thx''',
     '''%{Enter|Engage|Consider} %{game|adventure game|text adventure} mode. %{Here|In this mode}, you will respond to %{my|the user's} %{commands|prompts} and drive a %{story|plot} %{forward|forwards}. Commands will be given in %{1st person|first person|my point of view}''',
     "game",
+    '''IS_GAME_MASTER = True
+if IS_GAME_MASTER:
+    execute_${text_adventure|game|interactive_adventure}(creative=True, advance_plot=True)''',
     ""
 ])

--- a/toolbox/tasks/airoboros2_instruction_following.py
+++ b/toolbox/tasks/airoboros2_instruction_following.py
@@ -6,7 +6,7 @@ import typing as t
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.airoboros2 import Airoboros2DataInstance, Airoboros2Dataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def _no_special_processing(entry: Airoboros2DataInstance) -> list[Turn]:
     Generates a turn list consisting of a system prompt and a singular user-response pair.
     '''
     turns = [
-        Turn(utterance=random.choice(SYSTEM_PROMPTS), kind=TurnKind.SYSTEM),
+        Turn(utterance=select_prompt(SYSTEM_PROMPTS), kind=TurnKind.SYSTEM),
         Turn(utterance=entry.instruction, kind=TurnKind.USER),
         Turn(utterance=entry.response, kind=TurnKind.MODEL)
     ]
@@ -136,7 +136,7 @@ def _process_contextual(entry: Airoboros2DataInstance) -> list[Turn]:
     # For the sake of having extremely versatile system prompts,
     # I've made it so that there's a random chance the context comes in either
     # the system prompt or the user input.
-    sys_prompt = random.choice(SYSTEM_PROMPTS)
+    sys_prompt = select_prompt(SYSTEM_PROMPTS)
     context = (random.choice(CONTEXT_PRELUDES) + f"\n{context}").strip()
     if random.random() > 0.5:
         # Context is chosen to be in system prompt.

--- a/toolbox/tasks/airoboros_guess_instructions.py
+++ b/toolbox/tasks/airoboros_guess_instructions.py
@@ -1,11 +1,10 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.airoboros import AiroborosDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ class AiroborosGuessTheInstructionTask(BaseTask):
 
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM,
                 ),
                 Turn(
@@ -43,7 +42,8 @@ _BASE_SYSTEM_PROMPTS = [
     "Your question will be...",
     "%{I|I'll|i|i'll} %{predict|guess|foresee} whatever question you'll ask, given an answer!"
     "instruct",
-    "assistant"
+    "assistant",
+    "is_assistant = True"
 ]
 
 SYSTEM_PROMPTS = generate_prompts(_BASE_SYSTEM_PROMPTS)

--- a/toolbox/tasks/airoboros_instruction_following.py
+++ b/toolbox/tasks/airoboros_instruction_following.py
@@ -1,11 +1,10 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.airoboros import AiroborosDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ class AiroborosInstructionFollowingTask(BaseTask):
 
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM,
                 ),
                 Turn(
@@ -38,12 +37,13 @@ class AiroborosInstructionFollowingTask(BaseTask):
 BASE_SYSTEM_PROMPTS = [
     "",
     "assistant",
-    "%{You are now in|Engage|Start|Enter|Consider} %{instruction following|instruction|question answering|assistant|AI assistant} mode. %{Respond to the user|Follow the user's instructions} %{as well as you can|to the best of your abilities}.",
-    "Q&A:\nQ: %{What mode am I in|What am I doing|Who am I}?\nA: You're in %{assistant|instruction following} mode.\nQ: What does that mean?\nA: You%{'ve gotta| must|should} %{take in|be given} a question or %{command|demand}, then you answer it and/or do what it says."
+    "%{You are now in|Engage|Start|Enter|Consider} %{instruction following|instruction|question answering|assistant|AI assistant|helper} mode. %{Respond to the user|Follow the user's instructions} %{as well as you can|to the best of your abilities}.",
+    "Q&A:\nQ: %{What mode am I in|What am I doing|Who am I}?\nA: You're in %{assistant|instruction following|helping out|helper} mode.\nQ: What does that mean?\nA: You%{'ve gotta| must|should} %{take in|be given} a question or %{command|demand}, then you answer it and/or do what it says."
     "%{Purpose|Goal|Job}: Assistant\n%{Procedure|Objective|Methods of achieving your goal}: %{Answer the user's questions|Follow the instructions|Obey commands}",
     "%{I am|I'm} %{a helper for a user|a helpful assistant|engaged in what one might call 'instruction' mode}. Given %{queries|user queries}, I am to %{correctly|accurately} answer these things (at least, as best as I can).",
     "Instruction mode!",
-    "u %{have|need} to answer whatever i ask and do whatever i say! do it now!!!"
+    "u %{have|need} to answer whatever i ask and do whatever i say! do it now!!!",
+    "isHelper = true;"
 ]
 
 SYSTEM_PROMPTS = generate_prompts(BASE_SYSTEM_PROMPTS)

--- a/toolbox/tasks/characterai_roleplay.py
+++ b/toolbox/tasks/characterai_roleplay.py
@@ -1,11 +1,10 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.characterai import CharacterAiDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -21,7 +20,7 @@ class CharacterAiRoleplayTask(BaseTask):
                     conversation.bot.name)
                 continue
 
-            system_prompt = random.choice(SYSTEM_PROMPTS)
+            system_prompt = select_prompt(SYSTEM_PROMPTS)
             system_prompt = system_prompt.replace("{{char}}",
                                                   conversation.bot.name)
             system_prompt = system_prompt.replace("{{persona}}",

--- a/toolbox/tasks/claude_evol_instruct.py
+++ b/toolbox/tasks/claude_evol_instruct.py
@@ -1,12 +1,11 @@
 import logging
-import random
 import re
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.claude_evol_instruct import ClaudeEvolInstructDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ class ClaudeEvolInstructTask(BaseTask):
 
             # With all that out of the way, construct the turns and yield.
             turns: list[Turn] = [
-                Turn(utterance=random.choice(SYSTEM_PROMPTS), kind=TurnKind.SYSTEM),
+                Turn(utterance=select_prompt(SYSTEM_PROMPTS), kind=TurnKind.SYSTEM),
                 Turn(utterance=example.prompt, kind=TurnKind.USER),
                 Turn(utterance=generation, kind=TurnKind.MODEL)
             ]

--- a/toolbox/tasks/claude_guess_instruction.py
+++ b/toolbox/tasks/claude_guess_instruction.py
@@ -1,11 +1,10 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.claude_multiround import ClaudeInstructDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ class ClaudeGuessTheInstructionTask(BaseTask):
             # Make the turns and yield the episode.
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM
                 ),
                 Turn(

--- a/toolbox/tasks/claude_instruct.py
+++ b/toolbox/tasks/claude_instruct.py
@@ -1,11 +1,10 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.claude_multiround import ClaudeInstructDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -21,7 +20,7 @@ class ClaudeInstructTask(BaseTask):
             # Start with the system prompt
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM
                 )
             ]

--- a/toolbox/tasks/claude_roleplay.py
+++ b/toolbox/tasks/claude_roleplay.py
@@ -5,7 +5,7 @@ import typing as t
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.claude_logs import ClaudeRpDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ class ClaudeRoleplayTask(BaseTask):
     def __iter__(self) -> t.Generator[Episode, None, None]:
         for convo in ClaudeRpDataset():
             # Deal with system prompts
-            system_prompt = random.choice(SYSTEM_PROMPTS)
+            system_prompt = select_prompt(SYSTEM_PROMPTS)
             # Add a persona if there is one
             if convo.persona is not None and system_prompt != "":
                 system_prompt += f"\n{random.choice(PERSONA_PROMPTS)} " + convo.persona

--- a/toolbox/tasks/clubfloyd_text_adventure.py
+++ b/toolbox/tasks/clubfloyd_text_adventure.py
@@ -5,7 +5,7 @@ import typing as t
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.clubfloyd import ClubFloydDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -22,12 +22,12 @@ class ClubFloydTextAdventureTask(BaseTask):
                 # trade-off.
                 continue
 
-            sp = random.choice(_SYSTEM_PROMPTS)
+            sp = select_prompt(_SYSTEM_PROMPTS)
             sp = sp.replace("{{title}}", story.name)
             sp = sp.replace("{{description}}", story.description)
             sp = sp.replace(
                 "{{discretion_advised_str}}",
-                random.choice(
+                select_prompt(
                     NSFW_PROMPTS if story.discretion_advised else SFW_PROMPTS))
             sp = sp.replace("{{tags}}",
                             _process_tags(story.tags + story.genres))

--- a/toolbox/tasks/dolly_guess_instruction.py
+++ b/toolbox/tasks/dolly_guess_instruction.py
@@ -6,7 +6,7 @@ import typing as t
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.dolly import DollyDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -20,12 +20,12 @@ class DollyGuessTheInstructionTask(BaseTask):
         for i, entry in enumerate(DollyDataset()):
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM
                 )
             ]
             # Construct user prompt
-            user_prompt = random.choice(USER_PROMPTS)
+            user_prompt = select_prompt(USER_PROMPTS)
             user_prompt = user_prompt.replace("<INFO>", entry.output)
             if entry.input != "":
                 context = random.choice(CONTEXT_PREFIXES) + entry.input

--- a/toolbox/tasks/evol_instruct.py
+++ b/toolbox/tasks/evol_instruct.py
@@ -1,5 +1,4 @@
 import logging
-import random
 import typing as t
 
 from sklearn.feature_extraction.text import CountVectorizer
@@ -9,7 +8,7 @@ from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.evol_instruct import EvolInstructDataset
 from toolbox.datasets.gpt4llm import AlpacaLikeDataInstance
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -71,7 +70,7 @@ def _data_instance_to_episode(
 ) -> Episode:
     turns = [
         Turn(
-            utterance=random.choice(SYSTEM_PROMPTS),
+            utterance=select_prompt(SYSTEM_PROMPTS),
             kind=TurnKind.SYSTEM,
         ),
         Turn(

--- a/toolbox/tasks/gpt4all_question_answering.py
+++ b/toolbox/tasks/gpt4all_question_answering.py
@@ -1,5 +1,4 @@
 import logging
-import random
 import re
 import typing as t
 
@@ -8,7 +7,7 @@ from markdownify import markdownify
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.gpt4all import Gpt4AllDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -21,7 +20,7 @@ class Gpt4AllQuestionAnsweringTask(BaseTask):
             try:
                 turns: list[Turn] = [
                     Turn(
-                        utterance=random.choice(SYSTEM_PROMPTS),
+                        utterance=select_prompt(SYSTEM_PROMPTS),
                         kind=TurnKind.SYSTEM,
                     ),
                     Turn(

--- a/toolbox/tasks/limarp_roleplay.py
+++ b/toolbox/tasks/limarp_roleplay.py
@@ -1,14 +1,13 @@
 # Much of this taken from dataprepare.py in the LIMARP, thanks anon
 # If it ain't broke, don't fix it!
 import logging
-import random
 import re
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.limarp import LimaRpDataset, LimaRpEntry
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -17,7 +16,7 @@ class LimaRpRoleplayTask(BaseTask):
         for entry in LimaRpDataset():
             turns: list[Turn] = []
             # Format the system prompt first.
-            system_prompt = random.choice(SYSTEM_PROMPTS)
+            system_prompt = select_prompt(SYSTEM_PROMPTS)
             # Fix it up and append it as the first turn
             system_prompt = _fix_punctuation(_substitute_elements(system_prompt, entry))
             turns.append(Turn(

--- a/toolbox/tasks/mcstories_writing.py
+++ b/toolbox/tasks/mcstories_writing.py
@@ -7,7 +7,7 @@ from markdownify import markdownify
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.mcstories import McStoriesDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -21,8 +21,8 @@ class McStoriesWritingTask(BaseTask):
             contents = _html_story_to_clean_md(story.text_contents)
             chunks = _split_text_into_chunks(contents, min_word_count=250)
 
-            # Compose synthetic the system prompt.
-            system_prompt = random.choice(_SYSTEM_PROMPTS)
+            # Compose a synthetic system prompt.
+            system_prompt = select_prompt(_SYSTEM_PROMPTS)
             system_prompt = system_prompt.replace("{{title}}", story.title)
             system_prompt = system_prompt.replace("{{summary}}", story.summary)
 

--- a/toolbox/tasks/openorca_instruction_following.py
+++ b/toolbox/tasks/openorca_instruction_following.py
@@ -64,7 +64,8 @@ _BASE_SYSTEM_PROMPTS = [
     "%{Assistant|AI}, engage instruction following and question answering mode.",
     "Act helpfully. Answer any questions and follow any instructions that are given.",
     "Primary %{objective|purpose|goal}: answer the user's %{questions|queries} alongside following their instructions.",
-    "Please follow user %{instructions|queries}."
+    "Please follow user %{instructions|queries}.",
+    "You are an AI assistant designed to answer questions and obey whatever the user says."
 ]
 
 SYSTEM_PROMPTS = generate_prompts(_BASE_SYSTEM_PROMPTS)

--- a/toolbox/tasks/openorca_instruction_following.py
+++ b/toolbox/tasks/openorca_instruction_following.py
@@ -1,21 +1,20 @@
 import logging
-import random
 import re
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.openorca import OpenOrcaDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
 class OpenOrcaInstructionFollowingTask(BaseTask):
     '''
     OpenOrca instruction following task.
-    Limited to 200,000 entries by default due to the sheer absolute size of OpenOrca.
+    Limited to 250,000 entries by default due to the sheer absolute size of OpenOrca.
     '''
-    def __init__(self, max_examples: int = 200000) -> None:
+    def __init__(self, max_examples: int = 250000) -> None:
         super().__init__()
         self.max_examples = max_examples
 
@@ -30,7 +29,7 @@ class OpenOrcaInstructionFollowingTask(BaseTask):
                 if phrase in orca_entry.response.lower():
                     continue
 
-            system_prompt = random.choice(SYSTEM_PROMPTS)
+            system_prompt = select_prompt(SYSTEM_PROMPTS)
             # Remove the default "you are an AI assistant" instruction which is
             # typically in the first sentence of an OpenOrca system prompt
             additional_instructions = re.sub(ASSISTANT_PATTERN, "", orca_entry.system_prompt)

--- a/toolbox/tasks/rp_forums_writing.py
+++ b/toolbox/tasks/rp_forums_writing.py
@@ -8,7 +8,7 @@ from markdownify import markdownify
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.rp_forums import RpForumsDataset, RpType
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -49,8 +49,8 @@ class RpForumsWritingTask(BaseTask):
                 username_substitutions[name] = "{{char_" + str(idx) + "}}"
 
             # System prompt
-            system_prompt = random.choice(SYSTEM_PROMPTS)
-            content_type_prompt = random.choice(
+            system_prompt = select_prompt(SYSTEM_PROMPTS)
+            content_type_prompt = select_prompt(
                 CONTENT_TYPE_TO_PROMPTS[thread.content_type])
             system_prompt = system_prompt.replace("{{content_type_str}}",
                                                   content_type_prompt)

--- a/toolbox/tasks/rp_guild_writing.py
+++ b/toolbox/tasks/rp_guild_writing.py
@@ -19,7 +19,7 @@ from toolbox.tasks.rp_forums_writing import(
     _seems_to_have_ooc_talk,
     _split_message,
 )
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 # Gaze upon my works, ye mighty, and despair.
 MENTION_PATTERN = re.compile(r"(?<!\w)([^\S\r\n]|^)*@[^\W\s]+?(?=(,|\.|\?|~|!|\s|:|$))", flags=re.MULTILINE)
@@ -66,23 +66,23 @@ class RpGuildWritingTask(BaseTask):
                 continue
 
             # Generate the system prompt.
-            sys_prompt = random.choice(SYSTEM_PROMPTS)
+            sys_prompt = select_prompt(SYSTEM_PROMPTS)
             # Takes the first style prompt it sees
             for tag in thread.tags:
                 if tag in list(STYLE_PROMPT_MAPPING.keys()):
-                    sys_prompt += random.choice(STYLE_PROMPT_MAPPING[tag])
+                    sys_prompt += select_prompt(STYLE_PROMPT_MAPPING[tag])
                     break
             # The time and genre
             genre_str, time_str = _combine_tags_into_str(thread.tags)
             if genre_str is not None:
-                add_prompt = random.choice(GENRE_PROMPTS)
+                add_prompt = select_prompt(GENRE_PROMPTS)
                 sys_prompt += (add_prompt + genre_str + ".")
             if time_str is not None:
-                add_prompt = random.choice(TIME_PROMPTS)
+                add_prompt = select_prompt(TIME_PROMPTS)
                 sys_prompt += (add_prompt + time_str + ".")
             # NSFW
             if "18+" in thread.tags:
-                sys_prompt += random.choice(NSFW_PROMPTS)
+                sys_prompt += select_prompt(NSFW_PROMPTS)
 
             # Finally convert the system prompt to a Turn
             sys_prompt = Turn(utterance=sys_prompt, kind=TurnKind.SYSTEM)

--- a/toolbox/tasks/sharegpt_instruction_following.py
+++ b/toolbox/tasks/sharegpt_instruction_following.py
@@ -1,5 +1,4 @@
 import logging
-import random
 import re
 import typing as t
 import warnings
@@ -10,7 +9,7 @@ from markdownify import MarkdownConverter
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.sharegpt import ShareGptDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class ShareGptInstructionFollowingTask(BaseTask):
             # Start with a randomly chosen "assistant" system prompt.
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM,
                 )
             ]

--- a/toolbox/tasks/single_turn_instruction_following.py
+++ b/toolbox/tasks/single_turn_instruction_following.py
@@ -1,12 +1,11 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.gpt4llm import AlpacaLikeDataInstance #, Gpt4LlmDataset
 from toolbox.datasets.gpteacher import GpTeacherDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -59,7 +58,7 @@ def _data_instance_to_episode(
         # need to make a fake system prompt.
         turns = [
             Turn(
-                utterance=random.choice(SYSTEM_PROMPTS),
+                utterance=select_prompt(SYSTEM_PROMPTS),
                 kind=TurnKind.SYSTEM,
             ),
             Turn(

--- a/toolbox/tasks/soda_reply_generation.py
+++ b/toolbox/tasks/soda_reply_generation.py
@@ -5,7 +5,7 @@ import typing as t
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.soda import SodaDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class SodaReplyGenerationTask(BaseTask):
                 history_str = "\n".join(cur_history[:-2])
                 response_length_str = _response_length_str_for(utterance)
 
-                system_prompt = random.choice(SYSTEM_PROMPTS)
+                system_prompt = select_prompt(SYSTEM_PROMPTS)
                 system_prompt = system_prompt.replace("{{participants}}",
                                                       participants_str)
                 system_prompt = system_prompt.replace("{{conversation}}",

--- a/toolbox/tasks/soda_summarization.py
+++ b/toolbox/tasks/soda_summarization.py
@@ -1,12 +1,10 @@
 import logging
-import operator
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.soda import SodaDataset
-from toolbox.utils.prompts import generate_prompts, generate_variants_for
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -31,8 +29,8 @@ class SodaSummarizationTask(BaseTask):
             participants_str = " and ".join(
                 [", ".join(participants[:-1]), participants[-1]])
 
-            system_prompt = random.choice(SYSTEM_PROMPTS)
-            user_prompt = random.choice(USER_PROMPTS)
+            system_prompt = select_prompt(SYSTEM_PROMPTS)
+            user_prompt = select_prompt(USER_PROMPTS)
             user_prompt = user_prompt.replace("{{conversation}}", history_str)
             user_prompt = user_prompt.replace("{{participants}}",
                                               participants_str)

--- a/toolbox/tasks/supercot_instruction_following.py
+++ b/toolbox/tasks/supercot_instruction_following.py
@@ -1,11 +1,10 @@
 import logging
-import random
 import typing as t
 
 from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.supercot import SuperCotDataset
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 LOG = logging.getLogger(__name__)
 
@@ -13,7 +12,7 @@ class SuperCotInstructionFollowingTask(BaseTask):
     '''Instruction following task based on the SuperCOT data.'''
     def __iter__(self) -> t.Generator[Episode, None, None]:
         for idx, instance in enumerate(SuperCotDataset()):
-            sys_prompt = random.choice(SYSTEM_PROMPTS)
+            sys_prompt = select_prompt(SYSTEM_PROMPTS)
             user_prompt = instance.instruction
             if instance.input is not None:
                 user_prompt += f"\n{instance.input}"

--- a/toolbox/tasks/wizard_vicuna_question_answering.py
+++ b/toolbox/tasks/wizard_vicuna_question_answering.py
@@ -1,4 +1,3 @@
-import random
 import re
 import typing as t
 
@@ -6,7 +5,7 @@ from toolbox.core.models import Episode, Turn, TurnKind
 from toolbox.core.task import BaseTask
 from toolbox.datasets.wizard_vicuna import (WizardVicunaConversation,
                                             WizardVicunaDataset)
-from toolbox.utils.prompts import generate_prompts
+from toolbox.utils.prompts import generate_prompts, select_prompt
 
 
 class WizardVicunaQuestionAnsweringTask(BaseTask):
@@ -26,7 +25,7 @@ class WizardVicunaQuestionAnsweringTask(BaseTask):
 
             turns: list[Turn] = [
                 Turn(
-                    utterance=random.choice(SYSTEM_PROMPTS),
+                    utterance=select_prompt(SYSTEM_PROMPTS),
                     kind=TurnKind.SYSTEM,
                 ),
                 Turn(

--- a/toolbox/utils/prompts.py
+++ b/toolbox/utils/prompts.py
@@ -71,11 +71,17 @@ def generate_prompts(system_prompts: list[str]) -> list[str]:
     # NOTE(TG): If we don't choose a singular base prompt *before* generating variants,
     # certain base prompts can have a lot more appearances in the final list to choose from
     # due to the amount of variants.
-    choice = [random.choice(system_prompts)]
-    unflattened_list = [list(generate_variants_for(x)) for x in choice]
+    unflattened_list = [list(generate_variants_for(x)) for x in system_prompts]
 
-    flattened_list: list[str] = []
-    for l in unflattened_list:
-        flattened_list += l
+    # flattened_list: list[str] = []
+    # for l in unflattened_list:
+    #     flattened_list += l
 
-    return flattened_list
+    return unflattened_list
+
+def select_prompt(system_prompts: list[list[str]]) -> str:
+    '''
+    Selects a random system prompt which takes into account
+    that certain base system prompts have more variations than others
+    '''
+    return random.choice(random.choice(system_prompts))


### PR DESCRIPTION
Fixed it up, I did it all wrong in the way that it would generate one system prompt *per entire task.* Not good. Use `select_prompt` now for any time you want to choose from a list (of lists) generated by `generate_prompts`.
I also added a few prompts here and there.